### PR TITLE
Update to new AppEngine service

### DIFF
--- a/portfolio/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/portfolio/src/main/webapp/WEB-INF/appengine-web.xml
@@ -7,4 +7,5 @@
     <!-- prevent unwanted caching when accessing via the web preview server -->
     <include path="/**" expiration="0s" />
   </static-files>
+  <service>obiabii</service>
 </appengine-web-app>


### PR DESCRIPTION
I tested this with 

`mvn package appengine:deploy` and it gets deployed to https://obiabii-dot-step2020-277817.uc.r.appspot.com/. 

Feel free to suggest a different service name, it just gets appended to the front of the URL as you can see and should be different for the interns in this project, that's all.